### PR TITLE
Use `pkg` to build the component

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,11 +54,18 @@ jobs:
       - run: make build_provider
       - name: Create Provider Binaries
         run: make dist
+      - name: Create GH Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:
         nodeversion:
-          - 14.x
+          - 16.x
   publish_sdk:
     name: Publish SDKs
     runs-on: ubuntu-latest
@@ -140,7 +147,6 @@ jobs:
           - dotnet
           - go
         nodeversion:
-          - 14.x
+          - 16.x
         pythonversion:
           - "3.9"
-

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,6 @@ build_python_sdk:: gen_python_sdk
 	cd sdk/python/ && \
 		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e "s/\$${VERSION}/${PYPI_VERSION}/g" -e "s/\$${PLUGIN_VERSION}/${VERSION}/g" ./bin/setup.py && \
+		sed -i.bak -e "s/\0.0.0/${PYPI_VERSION}/g" -e "s/\0.0.0/${VERSION}/g" ./bin/setup.py && \
 		rm ./bin/setup.py.bak && \
 		cd ./bin && python3 setup.py build sdist

--- a/provider/cmd/pulumi-resource-aws-static-website/package.json
+++ b/provider/cmd/pulumi-resource-aws-static-website/package.json
@@ -1,8 +1,9 @@
 {
     "version": "${VERSION}",
+    "bin": "bin/index.js",
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
         "@pulumi/aws": "^5.0.0",
+        "@pulumi/pulumi": "^3.0.0",
         "blob": "^0.1.0",
         "fs": "0.0.1-security",
         "glob": "^8.0.1",
@@ -12,6 +13,7 @@
         "@types/glob": "^7.2.0",
         "@types/mime": "^2.0.3",
         "@types/node": "^10.0.0",
+        "pkg": "^5.8.0",
         "typescript": "~4.6.0"
     }
 }

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -8,11 +8,9 @@ This component makes it easy to deploy a static website to s3 along with an opti
 
 TypeScript:
 ```typescript
-const args =  {
-    sitePath: "../website/build",
-} as staticwebsite.WebsiteArgs
+const site = new staticwebsite.Website("website", {sitePath: "../website/build"});
 
-const site = new staticwebsite.Website("website", args);
+export const url = site.websiteURL;
 ```
 
 YAML:
@@ -30,16 +28,15 @@ outputs:
 
 TypeScript:
 ```typescript
-const args =  {
+const site = new staticwebsite.Website("website", {
     withCDN: true,
     sitePath: "../website/build",
     targetDomain: "my-awesome-site.com",
     withLogs: true,
     cacheTTL: 600,
-} as staticwebsite.WebsiteArgs
+});
 
-const site = new staticwebsite.Website("website", args);
-
+export const url = site.websiteURL;
 ```
 
 YAML:


### PR DESCRIPTION
This PR updates the build and release workflow to use `pkg` as defined in the boilerplate. 