### PR TITLE
getOrganizationName improvement

### DIFF
--- a/provider/cmd/pulumi-resource-aws-static-website/website.ts
+++ b/provider/cmd/pulumi-resource-aws-static-website/website.ts
@@ -129,9 +129,9 @@ export class Website extends pulumi.ComponentResource {
     }
 
     private getOrganizationName(): string {
-        const [ organization ] = execSync(`pulumi --stack='${pulumi.getStack()}' stack`)
+        const [ organization = '' ] = execSync(`pulumi --stack=${pulumi.getStack()} stack`)
             .toString()
-            .match(/(?<=Owner: )[^\n]+/)!;
+            .match(/(?<=Owner: )[^\n]+/) ?? [];
         return organization;
     }
 


### PR DESCRIPTION
Fixes issue #13:
- error when executing: `pulumi --stack='my-stack' stack` on windows terminals
- error when no match could be done against the result of `pulumi --stack=my-stack stack`
Example of a result with no matches that ended in error:
```
Current stack is dev:
    Managed by my_computer
    No updates yet; run `pulumi up`
Current stack resources (0):
    No resources currently in this stack
```