### PR TITLE
Add more fallbacks to getting org name

### DIFF
--- a/examples/jekyll/yaml/Pulumi.yaml
+++ b/examples/jekyll/yaml/Pulumi.yaml
@@ -6,5 +6,7 @@ resources:
     type: "aws-static-website:index:Website"
     properties:
       sitePath: "./_site"
+      atomicDeployments: true
 outputs:
   websiteURL: ${web.websiteURL}
+  bucketName: ${web.bucketName}

--- a/provider/cmd/pulumi-resource-aws-static-website/website.ts
+++ b/provider/cmd/pulumi-resource-aws-static-website/website.ts
@@ -131,7 +131,7 @@ export class Website extends pulumi.ComponentResource {
     private getOrganizationName(): string {
         const config = new pulumi.Config();
         const organizationNameOverride = config.get("pulumiOrganizationName");
-        if (organizationNameOverride && organizationNameOverride != "") {
+        if (organizationNameOverride) {
             return organizationNameOverride;
         }
 
@@ -140,7 +140,7 @@ export class Website extends pulumi.ComponentResource {
             .match(/(?<=Owner: )[^\n]+/) ?? [];
 
         if (organization == "") {
-            return execSync("pulumi whoami").toString();
+            throw new Error("pulumi organization not found, set the organization name in your config file to resolve this error by running `pulumi config set pulumiOrganizationName`");
         }
 
         return organization;

--- a/provider/cmd/pulumi-resource-aws-static-website/website.ts
+++ b/provider/cmd/pulumi-resource-aws-static-website/website.ts
@@ -140,7 +140,7 @@ export class Website extends pulumi.ComponentResource {
             .match(/(?<=Owner: )[^\n]+/) ?? [];
 
         if (organization == "") {
-            throw new Error("pulumi organization not found, set the organization name in your config file to resolve this error by running `pulumi config set pulumiOrganizationName`");
+            throw new Error("pulumi organization not found, set the organization name in your config file to resolve this error by running `pulumi config set pulumiOrganizationName <org name>`");
         }
 
         return organization;

--- a/sdk/go/aws-static-website/doc.go
+++ b/sdk/go/aws-static-website/doc.go
@@ -1,3 +1,2 @@
 // A Pulumi component to deploy a static website to AWS
-//
 package awsstaticwebsite

--- a/sdk/go/aws-static-website/website.go
+++ b/sdk/go/aws-static-website/website.go
@@ -123,7 +123,7 @@ func (i *Website) ToWebsiteOutputWithContext(ctx context.Context) WebsiteOutput 
 // WebsiteArrayInput is an input type that accepts WebsiteArray and WebsiteArrayOutput values.
 // You can construct a concrete instance of `WebsiteArrayInput` via:
 //
-//          WebsiteArray{ WebsiteArgs{...} }
+//	WebsiteArray{ WebsiteArgs{...} }
 type WebsiteArrayInput interface {
 	pulumi.Input
 
@@ -148,7 +148,7 @@ func (i WebsiteArray) ToWebsiteArrayOutputWithContext(ctx context.Context) Websi
 // WebsiteMapInput is an input type that accepts WebsiteMap and WebsiteMapOutput values.
 // You can construct a concrete instance of `WebsiteMapInput` via:
 //
-//          WebsiteMap{ "key": WebsiteArgs{...} }
+//	WebsiteMap{ "key": WebsiteArgs{...} }
 type WebsiteMapInput interface {
 	pulumi.Input
 


### PR DESCRIPTION
This PR updates the org name implementation to fallback to the username if my org name is found and adds a config value as an escape hatch.

Includes the changes from: https://github.com/pulumi/pulumi-aws-static-website/pull/14