### PR TITLE
Support subdomains

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -66,7 +66,7 @@
                 },
                 "subdomain": {
                     "type": "string",
-                    "description": "An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias."
+                    "description": "An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias or if a deeply nested subdomain is needed (e.g. foo.bar.baz.com)."
                 },
                 "sitePath": {
                     "type": "string",

--- a/schema.json
+++ b/schema.json
@@ -64,6 +64,10 @@
                     "type": "string",
                     "description": "The domain used to serve the content. A Route53 hosted zone must exist for this domain."
                 },
+                "subdomain": {
+                    "type": "string",
+                    "description": "An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias."
+                },
                 "sitePath": {
                     "type": "string",
                     "description": "The root directory containing the website's contents."

--- a/sdk/dotnet/Website.cs
+++ b/sdk/dotnet/Website.cs
@@ -131,7 +131,7 @@ namespace Pulumi.AwsStaticWebsite
         public Input<string> SitePath { get; set; } = null!;
 
         /// <summary>
-        /// An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias.
+        /// An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias or if a deeply nested subdomain is needed (e.g. foo.bar.baz.com).
         /// </summary>
         [Input("subdomain")]
         public Input<string>? Subdomain { get; set; }

--- a/sdk/dotnet/Website.cs
+++ b/sdk/dotnet/Website.cs
@@ -131,6 +131,12 @@ namespace Pulumi.AwsStaticWebsite
         public Input<string> SitePath { get; set; } = null!;
 
         /// <summary>
+        /// An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias.
+        /// </summary>
+        [Input("subdomain")]
+        public Input<string>? Subdomain { get; set; }
+
+        /// <summary>
         /// The domain used to serve the content. A Route53 hosted zone must exist for this domain.
         /// </summary>
         [Input("targetDomain")]

--- a/sdk/go/aws-static-website/website.go
+++ b/sdk/go/aws-static-website/website.go
@@ -65,7 +65,7 @@ type websiteArgs struct {
 	PriceClass *string `pulumi:"priceClass"`
 	// The root directory containing the website's contents.
 	SitePath string `pulumi:"sitePath"`
-	// An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias.
+	// An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias or if a deeply nested subdomain is needed (e.g. foo.bar.baz.com).
 	Subdomain *string `pulumi:"subdomain"`
 	// The domain used to serve the content. A Route53 hosted zone must exist for this domain.
 	TargetDomain *string `pulumi:"targetDomain"`
@@ -95,7 +95,7 @@ type WebsiteArgs struct {
 	PriceClass pulumi.StringPtrInput
 	// The root directory containing the website's contents.
 	SitePath pulumi.StringInput
-	// An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias.
+	// An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias or if a deeply nested subdomain is needed (e.g. foo.bar.baz.com).
 	Subdomain pulumi.StringPtrInput
 	// The domain used to serve the content. A Route53 hosted zone must exist for this domain.
 	TargetDomain pulumi.StringPtrInput

--- a/sdk/go/aws-static-website/website.go
+++ b/sdk/go/aws-static-website/website.go
@@ -65,6 +65,8 @@ type websiteArgs struct {
 	PriceClass *string `pulumi:"priceClass"`
 	// The root directory containing the website's contents.
 	SitePath string `pulumi:"sitePath"`
+	// An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias.
+	Subdomain *string `pulumi:"subdomain"`
 	// The domain used to serve the content. A Route53 hosted zone must exist for this domain.
 	TargetDomain *string `pulumi:"targetDomain"`
 	// Provision CloudFront CDN to serve content.
@@ -93,6 +95,8 @@ type WebsiteArgs struct {
 	PriceClass pulumi.StringPtrInput
 	// The root directory containing the website's contents.
 	SitePath pulumi.StringInput
+	// An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias.
+	Subdomain pulumi.StringPtrInput
 	// The domain used to serve the content. A Route53 hosted zone must exist for this domain.
 	TargetDomain pulumi.StringPtrInput
 	// Provision CloudFront CDN to serve content.

--- a/sdk/nodejs/website.ts
+++ b/sdk/nodejs/website.ts
@@ -134,7 +134,7 @@ export interface WebsiteArgs {
      */
     sitePath: pulumi.Input<string>;
     /**
-     * An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias.
+     * An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias or if a deeply nested subdomain is needed (e.g. foo.bar.baz.com).
      */
     subdomain?: pulumi.Input<string>;
     /**

--- a/sdk/nodejs/website.ts
+++ b/sdk/nodejs/website.ts
@@ -70,6 +70,7 @@ export class Website extends pulumi.ComponentResource {
             resourceInputs["indexHTML"] = args ? args.indexHTML : undefined;
             resourceInputs["priceClass"] = args ? args.priceClass : undefined;
             resourceInputs["sitePath"] = args ? args.sitePath : undefined;
+            resourceInputs["subdomain"] = args ? args.subdomain : undefined;
             resourceInputs["targetDomain"] = args ? args.targetDomain : undefined;
             resourceInputs["withCDN"] = args ? args.withCDN : undefined;
             resourceInputs["withLogs"] = args ? args.withLogs : undefined;
@@ -132,6 +133,10 @@ export interface WebsiteArgs {
      * The root directory containing the website's contents.
      */
     sitePath: pulumi.Input<string>;
+    /**
+     * An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias.
+     */
+    subdomain?: pulumi.Input<string>;
     /**
      * The domain used to serve the content. A Route53 hosted zone must exist for this domain.
      */

--- a/sdk/python/pulumi_aws_static_website/website.py
+++ b/sdk/python/pulumi_aws_static_website/website.py
@@ -24,6 +24,7 @@ class WebsiteArgs:
                  error404: Optional[pulumi.Input[str]] = None,
                  index_html: Optional[pulumi.Input[str]] = None,
                  price_class: Optional[pulumi.Input[str]] = None,
+                 subdomain: Optional[pulumi.Input[str]] = None,
                  target_domain: Optional[pulumi.Input[str]] = None,
                  with_cdn: Optional[pulumi.Input[bool]] = None,
                  with_logs: Optional[pulumi.Input[bool]] = None):
@@ -38,6 +39,7 @@ class WebsiteArgs:
         :param pulumi.Input[str] error404: default 404 page
         :param pulumi.Input[str] index_html: The default document for the site. Defaults to index.html
         :param pulumi.Input[str] price_class: The price class to use for the CloudFront configuration. Defaults to 100 if not specified. Valid values are `all`, `100`, and `200`
+        :param pulumi.Input[str] subdomain: An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias.
         :param pulumi.Input[str] target_domain: The domain used to serve the content. A Route53 hosted zone must exist for this domain.
         :param pulumi.Input[bool] with_cdn: Provision CloudFront CDN to serve content.
         :param pulumi.Input[bool] with_logs: Provision a bucket to hold access logs.
@@ -59,6 +61,8 @@ class WebsiteArgs:
             pulumi.set(__self__, "index_html", index_html)
         if price_class is not None:
             pulumi.set(__self__, "price_class", price_class)
+        if subdomain is not None:
+            pulumi.set(__self__, "subdomain", subdomain)
         if target_domain is not None:
             pulumi.set(__self__, "target_domain", target_domain)
         if with_cdn is not None:
@@ -175,6 +179,18 @@ class WebsiteArgs:
         pulumi.set(self, "price_class", value)
 
     @property
+    @pulumi.getter
+    def subdomain(self) -> Optional[pulumi.Input[str]]:
+        """
+        An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias.
+        """
+        return pulumi.get(self, "subdomain")
+
+    @subdomain.setter
+    def subdomain(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "subdomain", value)
+
+    @property
     @pulumi.getter(name="targetDomain")
     def target_domain(self) -> Optional[pulumi.Input[str]]:
         """
@@ -225,6 +241,7 @@ class Website(pulumi.ComponentResource):
                  index_html: Optional[pulumi.Input[str]] = None,
                  price_class: Optional[pulumi.Input[str]] = None,
                  site_path: Optional[pulumi.Input[str]] = None,
+                 subdomain: Optional[pulumi.Input[str]] = None,
                  target_domain: Optional[pulumi.Input[str]] = None,
                  with_cdn: Optional[pulumi.Input[bool]] = None,
                  with_logs: Optional[pulumi.Input[bool]] = None,
@@ -242,6 +259,7 @@ class Website(pulumi.ComponentResource):
         :param pulumi.Input[str] index_html: The default document for the site. Defaults to index.html
         :param pulumi.Input[str] price_class: The price class to use for the CloudFront configuration. Defaults to 100 if not specified. Valid values are `all`, `100`, and `200`
         :param pulumi.Input[str] site_path: The root directory containing the website's contents.
+        :param pulumi.Input[str] subdomain: An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias.
         :param pulumi.Input[str] target_domain: The domain used to serve the content. A Route53 hosted zone must exist for this domain.
         :param pulumi.Input[bool] with_cdn: Provision CloudFront CDN to serve content.
         :param pulumi.Input[bool] with_logs: Provision a bucket to hold access logs.
@@ -278,6 +296,7 @@ class Website(pulumi.ComponentResource):
                  index_html: Optional[pulumi.Input[str]] = None,
                  price_class: Optional[pulumi.Input[str]] = None,
                  site_path: Optional[pulumi.Input[str]] = None,
+                 subdomain: Optional[pulumi.Input[str]] = None,
                  target_domain: Optional[pulumi.Input[str]] = None,
                  with_cdn: Optional[pulumi.Input[bool]] = None,
                  with_logs: Optional[pulumi.Input[bool]] = None,
@@ -306,6 +325,7 @@ class Website(pulumi.ComponentResource):
             if site_path is None and not opts.urn:
                 raise TypeError("Missing required property 'site_path'")
             __props__.__dict__["site_path"] = site_path
+            __props__.__dict__["subdomain"] = subdomain
             __props__.__dict__["target_domain"] = target_domain
             __props__.__dict__["with_cdn"] = with_cdn
             __props__.__dict__["with_logs"] = with_logs

--- a/sdk/python/pulumi_aws_static_website/website.py
+++ b/sdk/python/pulumi_aws_static_website/website.py
@@ -39,7 +39,7 @@ class WebsiteArgs:
         :param pulumi.Input[str] error404: default 404 page
         :param pulumi.Input[str] index_html: The default document for the site. Defaults to index.html
         :param pulumi.Input[str] price_class: The price class to use for the CloudFront configuration. Defaults to 100 if not specified. Valid values are `all`, `100`, and `200`
-        :param pulumi.Input[str] subdomain: An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias.
+        :param pulumi.Input[str] subdomain: An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias or if a deeply nested subdomain is needed (e.g. foo.bar.baz.com).
         :param pulumi.Input[str] target_domain: The domain used to serve the content. A Route53 hosted zone must exist for this domain.
         :param pulumi.Input[bool] with_cdn: Provision CloudFront CDN to serve content.
         :param pulumi.Input[bool] with_logs: Provision a bucket to hold access logs.
@@ -182,7 +182,7 @@ class WebsiteArgs:
     @pulumi.getter
     def subdomain(self) -> Optional[pulumi.Input[str]]:
         """
-        An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias.
+        An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias or if a deeply nested subdomain is needed (e.g. foo.bar.baz.com).
         """
         return pulumi.get(self, "subdomain")
 
@@ -259,7 +259,7 @@ class Website(pulumi.ComponentResource):
         :param pulumi.Input[str] index_html: The default document for the site. Defaults to index.html
         :param pulumi.Input[str] price_class: The price class to use for the CloudFront configuration. Defaults to 100 if not specified. Valid values are `all`, `100`, and `200`
         :param pulumi.Input[str] site_path: The root directory containing the website's contents.
-        :param pulumi.Input[str] subdomain: An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias.
+        :param pulumi.Input[str] subdomain: An optional subdomain that can be used to serve the content. This can typically be used to provision a www alias or if a deeply nested subdomain is needed (e.g. foo.bar.baz.com).
         :param pulumi.Input[str] target_domain: The domain used to serve the content. A Route53 hosted zone must exist for this domain.
         :param pulumi.Input[bool] with_cdn: Provision CloudFront CDN to serve content.
         :param pulumi.Input[bool] with_logs: Provision a bucket to hold access logs.


### PR DESCRIPTION
issues: https://github.com/pulumi/pulumi-aws-static-website/issues/18 and https://github.com/pulumi/pulumi-aws-static-website/issues/17

This enables support for an additional subdomain to serve the content at, including support for a nested subdomain,  e.g. www, foo.bar.baz.com.