### PR TITLE
Add ability to assign cert without domain

### DIFF
--- a/provider/cmd/pulumi-resource-aws-static-website/website.ts
+++ b/provider/cmd/pulumi-resource-aws-static-website/website.ts
@@ -315,6 +315,15 @@ export class Website extends pulumi.ComponentResource {
                 cloudfrontDefaultCertificate: true,
                 sslSupportMethod: "sni-only",
             };
+
+            if (this.args.certificateARN) {
+                distributionArgs.viewerCertificate = {
+                    cloudfrontDefaultCertificate: false,
+                    acmCertificateArn: this.args.certificateARN,
+                    sslSupportMethod: "sni-only",
+                };
+            }
+
             cdn = new aws.cloudfront.Distribution(
                 "website-cdn",
                 distributionArgs,


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi-aws-static-website/issues/19

Adds a block to assign a certificate ARN if it is available.