### PR TITLE
Optional private content bucket

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -103,6 +103,10 @@
                 "atomicDeployments": {
                     "description": "Provision a new bucket on each deployment.",
                     "type": "boolean"
+                },
+                "contentBucketPrivate": {
+                    "description": "Optionally set to true to use a private ACL on the content bucket. Defaults to false for backwards compatibility. If enabled, only CloudFront can access the bucket through OAI.",
+                    "type": "boolean"
                 }
             },
             "requiredInputs": [

--- a/sdk/dotnet/Website.cs
+++ b/sdk/dotnet/Website.cs
@@ -107,6 +107,12 @@ namespace Pulumi.AwsStaticWebsite
         public Input<string>? CertificateARN { get; set; }
 
         /// <summary>
+        /// Optionally set to true to use a private ACL on the content bucket. Defaults to false for backwards compatibility. If enabled, only CloudFront can access the bucket through OAI.
+        /// </summary>
+        [Input("contentBucketPrivate")]
+        public Input<bool>? ContentBucketPrivate { get; set; }
+
+        /// <summary>
         /// default 404 page
         /// </summary>
         [Input("error404")]

--- a/sdk/go/aws-static-website/doc.go
+++ b/sdk/go/aws-static-website/doc.go
@@ -1,2 +1,3 @@
 // A Pulumi component to deploy a static website to AWS
+//
 package awsstaticwebsite

--- a/sdk/go/aws-static-website/pulumiTypes.go
+++ b/sdk/go/aws-static-website/pulumiTypes.go
@@ -25,7 +25,7 @@ type CDNArgs struct {
 // CDNArgsInput is an input type that accepts CDNArgsArgs and CDNArgsOutput values.
 // You can construct a concrete instance of `CDNArgsInput` via:
 //
-//	CDNArgsArgs{...}
+//          CDNArgsArgs{...}
 type CDNArgsInput interface {
 	pulumi.Input
 
@@ -67,11 +67,11 @@ func (i CDNArgsArgs) ToCDNArgsPtrOutputWithContext(ctx context.Context) CDNArgsP
 // CDNArgsPtrInput is an input type that accepts CDNArgsArgs, CDNArgsPtr and CDNArgsPtrOutput values.
 // You can construct a concrete instance of `CDNArgsPtrInput` via:
 //
-//	        CDNArgsArgs{...}
+//          CDNArgsArgs{...}
 //
-//	or:
+//  or:
 //
-//	        nil
+//          nil
 type CDNArgsPtrInput interface {
 	pulumi.Input
 

--- a/sdk/go/aws-static-website/website.go
+++ b/sdk/go/aws-static-website/website.go
@@ -57,6 +57,8 @@ type websiteArgs struct {
 	CdnArgs *CDNArgs `pulumi:"cdnArgs"`
 	// The ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process.
 	CertificateARN *string `pulumi:"certificateARN"`
+	// Optionally set to true to use a private ACL on the content bucket. Defaults to false for backwards compatibility. If enabled, only CloudFront can access the bucket through OAI.
+	ContentBucketPrivate *bool `pulumi:"contentBucketPrivate"`
 	// default 404 page
 	Error404 *string `pulumi:"error404"`
 	// The default document for the site. Defaults to index.html
@@ -87,6 +89,8 @@ type WebsiteArgs struct {
 	CdnArgs CDNArgsPtrInput
 	// The ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process.
 	CertificateARN pulumi.StringPtrInput
+	// Optionally set to true to use a private ACL on the content bucket. Defaults to false for backwards compatibility. If enabled, only CloudFront can access the bucket through OAI.
+	ContentBucketPrivate pulumi.BoolPtrInput
 	// default 404 page
 	Error404 pulumi.StringPtrInput
 	// The default document for the site. Defaults to index.html
@@ -131,7 +135,7 @@ func (i *Website) ToWebsiteOutputWithContext(ctx context.Context) WebsiteOutput 
 // WebsiteArrayInput is an input type that accepts WebsiteArray and WebsiteArrayOutput values.
 // You can construct a concrete instance of `WebsiteArrayInput` via:
 //
-//	WebsiteArray{ WebsiteArgs{...} }
+//          WebsiteArray{ WebsiteArgs{...} }
 type WebsiteArrayInput interface {
 	pulumi.Input
 
@@ -156,7 +160,7 @@ func (i WebsiteArray) ToWebsiteArrayOutputWithContext(ctx context.Context) Websi
 // WebsiteMapInput is an input type that accepts WebsiteMap and WebsiteMapOutput values.
 // You can construct a concrete instance of `WebsiteMapInput` via:
 //
-//	WebsiteMap{ "key": WebsiteArgs{...} }
+//          WebsiteMap{ "key": WebsiteArgs{...} }
 type WebsiteMapInput interface {
 	pulumi.Input
 

--- a/sdk/nodejs/website.ts
+++ b/sdk/nodejs/website.ts
@@ -66,6 +66,7 @@ export class Website extends pulumi.ComponentResource {
             resourceInputs["cacheTTL"] = args ? args.cacheTTL : undefined;
             resourceInputs["cdnArgs"] = args ? args.cdnArgs : undefined;
             resourceInputs["certificateARN"] = args ? args.certificateARN : undefined;
+            resourceInputs["contentBucketPrivate"] = args ? args.contentBucketPrivate : undefined;
             resourceInputs["error404"] = args ? args.error404 : undefined;
             resourceInputs["indexHTML"] = args ? args.indexHTML : undefined;
             resourceInputs["priceClass"] = args ? args.priceClass : undefined;
@@ -117,6 +118,10 @@ export interface WebsiteArgs {
      * The ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process.
      */
     certificateARN?: pulumi.Input<string>;
+    /**
+     * Optionally set to true to use a private ACL on the content bucket. Defaults to false for backwards compatibility. If enabled, only CloudFront can access the bucket through OAI.
+     */
+    contentBucketPrivate?: pulumi.Input<boolean>;
     /**
      * default 404 page
      */

--- a/sdk/python/pulumi_aws_static_website/website.py
+++ b/sdk/python/pulumi_aws_static_website/website.py
@@ -21,6 +21,7 @@ class WebsiteArgs:
                  cache_ttl: Optional[pulumi.Input[float]] = None,
                  cdn_args: Optional[pulumi.Input['CDNArgsArgs']] = None,
                  certificate_arn: Optional[pulumi.Input[str]] = None,
+                 content_bucket_private: Optional[pulumi.Input[bool]] = None,
                  error404: Optional[pulumi.Input[str]] = None,
                  index_html: Optional[pulumi.Input[str]] = None,
                  price_class: Optional[pulumi.Input[str]] = None,
@@ -36,6 +37,7 @@ class WebsiteArgs:
         :param pulumi.Input[float] cache_ttl: TTL in seconds for cached objects. 
         :param pulumi.Input['CDNArgsArgs'] cdn_args: Optional arguments used to configure the CDN.
         :param pulumi.Input[str] certificate_arn: The ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process.
+        :param pulumi.Input[bool] content_bucket_private: Optionally set to true to use a private ACL on the content bucket. Defaults to false for backwards compatibility. If enabled, only CloudFront can access the bucket through OAI.
         :param pulumi.Input[str] error404: default 404 page
         :param pulumi.Input[str] index_html: The default document for the site. Defaults to index.html
         :param pulumi.Input[str] price_class: The price class to use for the CloudFront configuration. Defaults to 100 if not specified. Valid values are `all`, `100`, and `200`
@@ -55,6 +57,8 @@ class WebsiteArgs:
             pulumi.set(__self__, "cdn_args", cdn_args)
         if certificate_arn is not None:
             pulumi.set(__self__, "certificate_arn", certificate_arn)
+        if content_bucket_private is not None:
+            pulumi.set(__self__, "content_bucket_private", content_bucket_private)
         if error404 is not None:
             pulumi.set(__self__, "error404", error404)
         if index_html is not None:
@@ -141,6 +145,18 @@ class WebsiteArgs:
     @certificate_arn.setter
     def certificate_arn(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "certificate_arn", value)
+
+    @property
+    @pulumi.getter(name="contentBucketPrivate")
+    def content_bucket_private(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Optionally set to true to use a private ACL on the content bucket. Defaults to false for backwards compatibility. If enabled, only CloudFront can access the bucket through OAI.
+        """
+        return pulumi.get(self, "content_bucket_private")
+
+    @content_bucket_private.setter
+    def content_bucket_private(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "content_bucket_private", value)
 
     @property
     @pulumi.getter
@@ -237,6 +253,7 @@ class Website(pulumi.ComponentResource):
                  cache_ttl: Optional[pulumi.Input[float]] = None,
                  cdn_args: Optional[pulumi.Input[pulumi.InputType['CDNArgsArgs']]] = None,
                  certificate_arn: Optional[pulumi.Input[str]] = None,
+                 content_bucket_private: Optional[pulumi.Input[bool]] = None,
                  error404: Optional[pulumi.Input[str]] = None,
                  index_html: Optional[pulumi.Input[str]] = None,
                  price_class: Optional[pulumi.Input[str]] = None,
@@ -255,6 +272,7 @@ class Website(pulumi.ComponentResource):
         :param pulumi.Input[float] cache_ttl: TTL in seconds for cached objects. 
         :param pulumi.Input[pulumi.InputType['CDNArgsArgs']] cdn_args: Optional arguments used to configure the CDN.
         :param pulumi.Input[str] certificate_arn: The ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process.
+        :param pulumi.Input[bool] content_bucket_private: Optionally set to true to use a private ACL on the content bucket. Defaults to false for backwards compatibility. If enabled, only CloudFront can access the bucket through OAI.
         :param pulumi.Input[str] error404: default 404 page
         :param pulumi.Input[str] index_html: The default document for the site. Defaults to index.html
         :param pulumi.Input[str] price_class: The price class to use for the CloudFront configuration. Defaults to 100 if not specified. Valid values are `all`, `100`, and `200`
@@ -292,6 +310,7 @@ class Website(pulumi.ComponentResource):
                  cache_ttl: Optional[pulumi.Input[float]] = None,
                  cdn_args: Optional[pulumi.Input[pulumi.InputType['CDNArgsArgs']]] = None,
                  certificate_arn: Optional[pulumi.Input[str]] = None,
+                 content_bucket_private: Optional[pulumi.Input[bool]] = None,
                  error404: Optional[pulumi.Input[str]] = None,
                  index_html: Optional[pulumi.Input[str]] = None,
                  price_class: Optional[pulumi.Input[str]] = None,
@@ -319,6 +338,7 @@ class Website(pulumi.ComponentResource):
             __props__.__dict__["cache_ttl"] = cache_ttl
             __props__.__dict__["cdn_args"] = cdn_args
             __props__.__dict__["certificate_arn"] = certificate_arn
+            __props__.__dict__["content_bucket_private"] = content_bucket_private
             __props__.__dict__["error404"] = error404
             __props__.__dict__["index_html"] = index_html
             __props__.__dict__["price_class"] = price_class


### PR DESCRIPTION
issues: #22 

This adds optional support for setting the content S3 bucket to private. When using this bucket with CloudFront's origin access identity, it should not be required to set the bucket itself to public if we only need CloudFront to access it.