### PR TITLE
Add error403 parameter to handle 403 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This component takes the following inputs.
 - targetDomain (string) - the domain used to serve the content. A Route53 hosted zone must exist for this domain is this option is specified
 - index.html (string) - the default document for the site. Defaults to index.html
 - error404 (string) - the default 404 error page
+- error403 (string) - the default 403 error page
 - certificateARN (string) - the ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process
 - cacheTTL (number) - TTL in seconds for cached objects
 - withLogs (boolean) - provision a bucket to house access logs

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -43,6 +43,7 @@ This component takes the following inputs.
 - withCDN - provision a CloudFront CDN to serve content
 - targetDomain - the domain used to serve the content. A Route53 hosted zone must exist for this domain is this option is specified
 - index.html - the default document for the site. Defaults to index.html
+- error403 - the default 403 error page
 - error404 - the default 404 error page
 - certificateARN - the ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process
 - cacheTTL - TTL inseconds for cached objects

--- a/provider/cmd/pulumi-resource-aws-static-website/website.ts
+++ b/provider/cmd/pulumi-resource-aws-static-website/website.ts
@@ -30,6 +30,7 @@ interface CdnArgs {
 export interface WebsiteArgs {
     sitePath: string;
     indexHTML: string;
+    error403?: string;
     error404: string;
     withCDN: boolean;
     cdnArgs?: CdnArgs;
@@ -86,6 +87,11 @@ export class Website extends pulumi.ComponentResource {
         // Check the error document exists if specified.
         if (args.error404 && !fs.existsSync(path.join(args.sitePath, args.error404))) {
             pulumi.log.warn(`Default document "${args.error404}" does not exist.`);
+        }
+
+        // Check the error document exists if specified.
+        if (args.error403 && !fs.existsSync(path.join(args.sitePath, args.error403))) {
+            pulumi.log.warn(`Default document "${args.error403}" does not exist.`);
         }
 
         // Get the current stack and check the outputs.
@@ -532,7 +538,8 @@ export class Website extends pulumi.ComponentResource {
             // You can customize error responses. When CloudFront receives an error from the origin (e.g. S3 or some other
             // web service) it can return a different error code, and return the response for a different resource.
             customErrorResponses: [
-                { errorCode: 404, responseCode: 404, responsePagePath: `/${this.args.error404}` }
+                { errorCode: 404, responseCode: 404, responsePagePath: `/${this.args.error404}` },
+                { errorCode: 403, responseCode: 403, responsePagePath: `/${this.args.error403}` }
             ],
 
             restrictions: {

--- a/schema.json
+++ b/schema.json
@@ -100,6 +100,10 @@
                     "type": "string",
                     "description": "The default document for the site. Defaults to index.html"
                 },
+                "error403": {
+                    "type": "string",
+                    "description": "default 403 page"
+                },
                 "error404": {
                     "type": "string",
                     "description": "default 404 page"

--- a/sdk/dotnet/Website.cs
+++ b/sdk/dotnet/Website.cs
@@ -107,6 +107,12 @@ namespace Pulumi.AwsStaticWebsite
         public Input<string>? CertificateARN { get; set; }
 
         /// <summary>
+        /// default 403 page
+        /// </summary>
+        [Input("error403")]
+        public Input<string>? Error403 { get; set; }
+
+        /// <summary>
         /// default 404 page
         /// </summary>
         [Input("error404")]

--- a/sdk/go/aws-static-website/website.go
+++ b/sdk/go/aws-static-website/website.go
@@ -57,6 +57,8 @@ type websiteArgs struct {
 	CdnArgs *CDNArgs `pulumi:"cdnArgs"`
 	// The ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process.
 	CertificateARN *string `pulumi:"certificateARN"`
+	// default 403 page
+	Error403 *string `pulumi:"error403"`
 	// default 404 page
 	Error404 *string `pulumi:"error404"`
 	// The default document for the site. Defaults to index.html
@@ -87,6 +89,8 @@ type WebsiteArgs struct {
 	CdnArgs CDNArgsPtrInput
 	// The ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process.
 	CertificateARN pulumi.StringPtrInput
+	// default 403 page
+	Error403 pulumi.StringPtrInput
 	// default 404 page
 	Error404 pulumi.StringPtrInput
 	// The default document for the site. Defaults to index.html

--- a/sdk/nodejs/website.ts
+++ b/sdk/nodejs/website.ts
@@ -67,6 +67,7 @@ export class Website extends pulumi.ComponentResource {
             resourceInputs["cacheTTL"] = args ? args.cacheTTL : undefined;
             resourceInputs["cdnArgs"] = args ? args.cdnArgs : undefined;
             resourceInputs["certificateARN"] = args ? args.certificateARN : undefined;
+            resourceInputs["error403"] = args ? args.error403 : undefined;
             resourceInputs["error404"] = args ? args.error404 : undefined;
             resourceInputs["indexHTML"] = args ? args.indexHTML : undefined;
             resourceInputs["priceClass"] = args ? args.priceClass : undefined;
@@ -118,6 +119,10 @@ export interface WebsiteArgs {
      * The ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process.
      */
     certificateARN?: pulumi.Input<string>;
+    /**
+     * default 403 page
+     */
+    error403?: pulumi.Input<string>;
     /**
      * default 404 page
      */

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -90,6 +90,7 @@ This component takes the following inputs.
 - targetDomain (string) - the domain used to serve the content. A Route53 hosted zone must exist for this domain is this option is specified
 - index.html (string) - the default document for the site. Defaults to index.html
 - error404 (string) - the default 404 error page
+- error403 (string) - the default 403 error page
 - certificateARN (string) - the ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process
 - cacheTTL (number) - TTL in seconds for cached objects
 - withLogs (boolean) - provision a bucket to house access logs

--- a/sdk/python/pulumi_aws_static_website/website.py
+++ b/sdk/python/pulumi_aws_static_website/website.py
@@ -22,6 +22,7 @@ class WebsiteArgs:
                  cache_ttl: Optional[pulumi.Input[float]] = None,
                  cdn_args: Optional[pulumi.Input['CDNArgsArgs']] = None,
                  certificate_arn: Optional[pulumi.Input[str]] = None,
+                 error403: Optional[pulumi.Input[str]] = None,
                  error404: Optional[pulumi.Input[str]] = None,
                  index_html: Optional[pulumi.Input[str]] = None,
                  price_class: Optional[pulumi.Input[str]] = None,
@@ -37,6 +38,7 @@ class WebsiteArgs:
         :param pulumi.Input[float] cache_ttl: TTL in seconds for cached objects. 
         :param pulumi.Input['CDNArgsArgs'] cdn_args: Optional arguments used to configure the CDN.
         :param pulumi.Input[str] certificate_arn: The ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process.
+        :param pulumi.Input[str] error403: default 403 page
         :param pulumi.Input[str] error404: default 404 page
         :param pulumi.Input[str] index_html: The default document for the site. Defaults to index.html
         :param pulumi.Input[str] price_class: The price class to use for the CloudFront configuration. Defaults to 100 if not specified. Valid values are `all`, `100`, and `200`
@@ -56,6 +58,8 @@ class WebsiteArgs:
             pulumi.set(__self__, "cdn_args", cdn_args)
         if certificate_arn is not None:
             pulumi.set(__self__, "certificate_arn", certificate_arn)
+        if error403 is not None:
+            pulumi.set(__self__, "error403", error403)
         if error404 is not None:
             pulumi.set(__self__, "error404", error404)
         if index_html is not None:
@@ -142,6 +146,18 @@ class WebsiteArgs:
     @certificate_arn.setter
     def certificate_arn(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "certificate_arn", value)
+
+    @property
+    @pulumi.getter
+    def error403(self) -> Optional[pulumi.Input[str]]:
+        """
+        default 403 page
+        """
+        return pulumi.get(self, "error403")
+
+    @error403.setter
+    def error403(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "error403", value)
 
     @property
     @pulumi.getter
@@ -238,6 +254,7 @@ class Website(pulumi.ComponentResource):
                  cache_ttl: Optional[pulumi.Input[float]] = None,
                  cdn_args: Optional[pulumi.Input[pulumi.InputType['CDNArgsArgs']]] = None,
                  certificate_arn: Optional[pulumi.Input[str]] = None,
+                 error403: Optional[pulumi.Input[str]] = None,
                  error404: Optional[pulumi.Input[str]] = None,
                  index_html: Optional[pulumi.Input[str]] = None,
                  price_class: Optional[pulumi.Input[str]] = None,
@@ -256,6 +273,7 @@ class Website(pulumi.ComponentResource):
         :param pulumi.Input[float] cache_ttl: TTL in seconds for cached objects. 
         :param pulumi.Input[pulumi.InputType['CDNArgsArgs']] cdn_args: Optional arguments used to configure the CDN.
         :param pulumi.Input[str] certificate_arn: The ARN of the ACM certificate to use for serving HTTPS. If one is not provided, a certificate will be created during the provisioning process.
+        :param pulumi.Input[str] error403: default 403 page
         :param pulumi.Input[str] error404: default 404 page
         :param pulumi.Input[str] index_html: The default document for the site. Defaults to index.html
         :param pulumi.Input[str] price_class: The price class to use for the CloudFront configuration. Defaults to 100 if not specified. Valid values are `all`, `100`, and `200`
@@ -293,6 +311,7 @@ class Website(pulumi.ComponentResource):
                  cache_ttl: Optional[pulumi.Input[float]] = None,
                  cdn_args: Optional[pulumi.Input[pulumi.InputType['CDNArgsArgs']]] = None,
                  certificate_arn: Optional[pulumi.Input[str]] = None,
+                 error403: Optional[pulumi.Input[str]] = None,
                  error404: Optional[pulumi.Input[str]] = None,
                  index_html: Optional[pulumi.Input[str]] = None,
                  price_class: Optional[pulumi.Input[str]] = None,
@@ -317,6 +336,7 @@ class Website(pulumi.ComponentResource):
             __props__.__dict__["cache_ttl"] = cache_ttl
             __props__.__dict__["cdn_args"] = cdn_args
             __props__.__dict__["certificate_arn"] = certificate_arn
+            __props__.__dict__["error403"] = error403
             __props__.__dict__["error404"] = error404
             __props__.__dict__["index_html"] = index_html
             __props__.__dict__["price_class"] = price_class


### PR DESCRIPTION
Add the ability to redirect 403 errors on websites.

* **provider/cmd/pulumi-resource-aws-static-website/website.ts**
  - Add `error403` parameter to `WebsiteArgs` interface.
  - Add check for existence of `error403` document.
  - Update `customErrorResponses` property in CloudFront distribution configuration to include 403 error configuration.

* **README.md**
  - Update documentation to include the new `error403` parameter.

* **schema.json**
  - Add `error403` parameter to `WebsiteArgs` type definition.